### PR TITLE
Add support for optional documentation comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 jProperties for Python |pypi-badge|
-=====================================
+===================================
 
 jProperties is a Java Property file parser and writer for Python. It aims to provide the same functionality
 as `Java's Properties class <http://docs.oracle.com/javase/7/docs/api/java/util/Properties.html>`_, although
@@ -88,6 +88,37 @@ Note that metadata support is always enabled. The only thing that is optional is
 Metadata keys beginning with two underscores (``__``) are not written to the output stream by the ``store()`` method.
 Thus, they can be used to attach "runtime-only" metadata to properties. Currently, however, metadata with such keys is
 still read from the input stream by ``load()``; this should probably be considered erroneous behaviour.
+
+Documenting Properties
+^^^^^^^^^^^^^^^^^^^^^^
+
+The comments after a property definition can be added to the metadata
+with the key ``_doc`` if the ``metadoc=True`` optional argument is given
+to the ``load`` method.  This allows properties to be documented in the
+properties file.  For example, the properties file::
+
+    #: _severity=fatal
+    10001=Fatal internal error: %s
+    # A fatal internal error occurred.  Please re-run the command
+    # with the -D option to generate additional debug information.
+
+The following example code shows how this documentation can be accessed.
+
+.. code:: text
+
+    from jproperties import Properties
+
+    p = Properties()
+    with open("foobar.properties", "rb") as f:
+        p.load(f, "utf-8", metadoc=True)
+    # Print the explicitly defined '_severity' metadata
+    print("Severity: ", p.getmeta("10001")['_severity'])
+    # Print the implicitly defined '_doc' metadata
+    print("Explanation: ", p.getmeta("10001")['_doc'])
+
+The documentation can extracted from properties files and used to generate
+pages in the overall system documentation or can be accessed via options
+for command line utilities.
 
 Caveats
 ^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ The following example code shows how this documentation can be accessed.
     # Print the implicitly defined '_doc' metadata
     print("Explanation: ", p.getmeta("10001")['_doc'])
 
-The documentation can extracted from properties files and used to generate
+The documentation can be extracted from properties files and used to generate
 pages in the overall system documentation or can be accessed via options
 for command line utilities.
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ properties file.  For example, the properties file::
 
 The following example code shows how this documentation can be accessed.
 
-.. code:: text
+.. code:: python
 
     from jproperties import Properties
 

--- a/jproperties.py
+++ b/jproperties.py
@@ -450,14 +450,19 @@ class Properties(MutableMapping, object):
         (which is skipped as well).
 
         :return: The text on the line.
-        :raise: EOFError and IOError.
+        :raise: IOError.
         """
         line = ""
-        while self._peek() not in self._EOL:
-            line += self._getc()
 
-        # Increment line count if needed.
-        self._handle_eol()
+        try:
+            while self._peek() not in self._EOL:
+                line += self._getc()
+
+            # Increment line count if needed.
+            self._handle_eol()
+        except EOFError:
+            pass
+
         return line
 
     def _parse_comment(self):

--- a/jproperties.py
+++ b/jproperties.py
@@ -449,14 +449,16 @@ class Properties(MutableMapping, object):
         This simply skips all characters until a line terminator sequence is encountered
         (which is skipped as well).
 
-        :return: None.
+        :return: The text on the line.
         :raise: EOFError and IOError.
         """
+        line = ""
         while self._peek() not in self._EOL:
-            self._getc()
+            line += self._getc()
 
         # Increment line count if needed.
         self._handle_eol()
+        return line
 
     def _parse_comment(self):
         """
@@ -475,7 +477,13 @@ class Properties(MutableMapping, object):
 
         # If the next character is a colon, then this is a metadata comment. If not, then we skip this comment.
         if self._peek() != ":":
-            self._skip_natural_line()
+            docstr = self._skip_natural_line()
+            if self._metadoc and self._prev_key:
+                prev_metadata = self._metadata.setdefault(self._prev_key, {})
+                prev_metadata.setdefault('_doc', "")
+                if docstr.startswith(" "):
+                   docstr = docstr[1:]
+                prev_metadata['_doc'] += docstr + "\n"
             return
 
         # Skip the metadata marker (the colon).
@@ -712,6 +720,7 @@ class Properties(MutableMapping, object):
         if len(self._next_metadata):
             self._metadata[key] = self._next_metadata
             self._next_metadata = {}
+        self._prev_key = key
 
         return True
 
@@ -726,7 +735,7 @@ class Properties(MutableMapping, object):
             pass
 
     # noinspection PyAttributeOutsideInit
-    def reset(self):
+    def reset(self, metadoc=False):
         """
         Reset the parser state so that a new file can be parsed.
 
@@ -746,6 +755,12 @@ class Properties(MutableMapping, object):
         # Parsed metadata for the next key-value pair.
         self._next_metadata = {}
 
+        # The handle comments after the key/value pair as documentation
+        # need the previous key (to update the associated metadata) and
+        # the flag on whether or not this handling should happen.
+        self._prev_key = None
+        self._metadoc = metadoc
+
     # noinspection PyAttributeOutsideInit
     def clear(self):
         """
@@ -762,7 +777,7 @@ class Properties(MutableMapping, object):
         # Key order. Populated when parsing so that key order can be preserved when writing the data back.
         self._key_order = []
 
-    def load(self, source_data, encoding="iso-8859-1"):
+    def load(self, source_data, encoding="iso-8859-1", metadoc=False):
         """
         Load, decode and parse an input stream (or string).
 
@@ -776,7 +791,7 @@ class Properties(MutableMapping, object):
         :raise: IOError, EOFError, ParseError, UnicodeDecodeError (if source_data needs to be decoded),
                  LookupError (if encoding is unknown).
         """
-        self.reset()
+        self.reset(metadoc)
 
         if isinstance(source_data, six.binary_type):
             # Byte string. Need to decode.

--- a/jproperties.py
+++ b/jproperties.py
@@ -755,7 +755,7 @@ class Properties(MutableMapping, object):
         # Parsed metadata for the next key-value pair.
         self._next_metadata = {}
 
-        # The handle comments after the key/value pair as documentation
+        # To handle comments after the key/value pair as documentation, we
         # need the previous key (to update the associated metadata) and
         # the flag on whether or not this handling should happen.
         self._prev_key = None

--- a/tests/test_docstrs.py
+++ b/tests/test_docstrs.py
@@ -1,0 +1,25 @@
+from jproperties import Properties
+
+def test_skip_docstr():
+    p = Properties()
+    p.load("# A comment\nK = V")
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {}
+
+def test_simple_docstr():
+    p = Properties()
+    p.load("#\nK = V\n# A comment\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n"}
+
+def test_simple_docstr_w_meta():
+    p = Properties()
+    p.load("#: metakey=42\nK = V\n# A comment\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n", "metakey": '42'}
+
+def test_multiline_docstr():
+    p = Properties()
+    p.load("#\nK = V\n# A comment\n#   more comments\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n  more comments\n"}

--- a/tests/test_docstrs.py
+++ b/tests/test_docstrs.py
@@ -12,6 +12,12 @@ def test_simple_docstr():
     assert p.properties == {"K": "V"}
     assert p.getmeta("K") == {"_doc": "A comment\n"}
 
+def test_simple_docstr_without_eol():
+    p = Properties()
+    p.load("#\nK = V\n# A comment", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n"}
+
 def test_simple_docstr_w_meta():
     p = Properties()
     p.load("#: metakey=42\nK = V\n# A comment\n", metadoc=True)
@@ -21,6 +27,12 @@ def test_simple_docstr_w_meta():
 def test_multiline_docstr():
     p = Properties()
     p.load("#\nK = V\n# A comment\n#   more comments\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n  more comments\n"}
+
+def test_multiline_docstr_without_eol():
+    p = Properties()
+    p.load("#\nK = V\n# A comment\n#   more comments", metadoc=True)
     assert p.properties == {"K": "V"}
     assert p.getmeta("K") == {"_doc": "A comment\n  more comments\n"}
 

--- a/tests/test_docstrs.py
+++ b/tests/test_docstrs.py
@@ -2,7 +2,7 @@ from jproperties import Properties
 
 def test_skip_docstr():
     p = Properties()
-    p.load("# A comment\nK = V")
+    p.load("# A comment\nK = V\n# More comments\n")
     assert p.properties == {"K": "V"}
     assert p.getmeta("K") == {}
 
@@ -23,3 +23,9 @@ def test_multiline_docstr():
     p.load("#\nK = V\n# A comment\n#   more comments\n", metadoc=True)
     assert p.properties == {"K": "V"}
     assert p.getmeta("K") == {"_doc": "A comment\n  more comments\n"}
+
+def test_multiline_docstr_with_empty_lines():
+    p = Properties()
+    p.load("K = V\n# A comment\n#   more comments\n\n\n# trailer\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n  more comments\ntrailer\n"}

--- a/tests/test_docstrs.py
+++ b/tests/test_docstrs.py
@@ -41,3 +41,9 @@ def test_multiline_docstr_with_empty_lines():
     p.load("K = V\n# A comment\n#   more comments\n\n\n# trailer\n", metadoc=True)
     assert p.properties == {"K": "V"}
     assert p.getmeta("K") == {"_doc": "A comment\n  more comments\ntrailer\n"}
+
+def test_multiline_docstr_with_empty_comment_lines():
+    p = Properties()
+    p.load("K = V\n# A comment\n#   more comments\n#\n# trailer\n", metadoc=True)
+    assert p.properties == {"K": "V"}
+    assert p.getmeta("K") == {"_doc": "A comment\n  more comments\n\ntrailer\n"}


### PR DESCRIPTION
Added a load option to interpret comments after properties as
documentation text for the key defined.  The text is added to
the metadata with the key "_doc".  E.g., the properties file
contents (from the README.rst):

    #: _severity=fatal
    10001=Fatal internal error: %s
    # A fatal internal error occurred.  Please re-run the command
    # with the -D option to generate additional debug information.

defines the "_severity" metadata key and, when "metadoc=True"
is used when loading, the additional key "_doc" with the value

    A fatal internal error occurred.  Please re-run the command
    with the -D option to generate additional debug information.

Signed-off-by: Michael Rohan <mrohan@vmware.com>