### PR TITLE
Using collections.abc when python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 
 # vim files
 .*.swp
+
+# virtualenv
+.python_jproperties

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -1,0 +1,42 @@
+Development Environment
+=======================
+
+Suggestion 1
+~~~~~~~~~~~~
+Use `pyenv <https://github.com/pyenv/pyenv>`_, and install all the versions supported by the plugin.
+Double-check on `tox.ini <./tox.ini>`_.
+
+.. code-block:: shell
+    pyenv install 2.7.18
+
+    pyenv install 3.5.9
+
+    pyenv install 3.6.10
+
+    pyenv install 3.7.7
+
+    pyenv install 3.8.3
+
+Set the installed versions as global, that will allow tox to find all of them.
+
+.. code-block:: shell
+
+    pyenv global 2.7.18 3.5.9 3.6.10 3.7.7 3.8.3
+
+Create virtualenv, install dependencies, run tests, and tox:
+
+.. code-block:: shell
+
+    python3.8 -m venv .python_jproperties
+
+    source .python_jproperties/bin/activate
+
+    pip install --upgrade setuptools pip tox
+
+    python setup.py install
+
+    python setup.py test
+
+    tox
+
+The development environment is complete.

--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,13 @@ The ``properties`` property is nevertheless useful to set many default values be
     file_obj = codecs.open("foobar.properties", "rb", "iso-8859-1")
     prop_obj.load(file_obj, encoding=None)
 
+
+Development
+++++++++++++++++
+
+If you want to help development, there is
+`overview documentation <./DEVELOPMENT.rst>`_
+
 Version history
 ---------------
 

--- a/jproperties.py
+++ b/jproperties.py
@@ -37,7 +37,13 @@ import os
 import re
 import sys
 import time
-from collections import MutableMapping, namedtuple
+from collections import namedtuple
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    # python2
+    from collections import MutableMapping
 
 import six
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development"
     ],
     license="BSD 3-Clause License; partially licensed under the Python Software Foundation License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
closes #7 

- Adding support to python3.6, python 3.7, and python3.8
- Using collections.abc when python3
- Adding some development environment suggestion as documentation

