### PR TITLE
Fix deprecation warning for Python > 3.3 and error for Python 3.10

### DIFF
--- a/jproperties.py
+++ b/jproperties.py
@@ -35,9 +35,15 @@ import functools
 import itertools
 import os
 import re
+import struct
 import sys
 import time
-from collections import MutableMapping, namedtuple
+
+if sys.version_info < (3, 3):
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
+from collections import namedtuple
 
 import six
 
@@ -595,8 +601,11 @@ class Properties(MutableMapping, object):
                     final_codepoint += codepoint2 & 0x03FF
 
                     codepoint = final_codepoint
+                try:
+                    return six.unichr(codepoint)
+                except ValueError:
+                    return struct.pack('i', codepoint).decode('utf-32')
 
-                return six.unichr(codepoint)
             except (EOFError, ValueError) as e:
                 raise ParseError(str(e), start_linenumber, self._source_file)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     tests_require=[
         "pytest",
         "pytest-cov",
-        "pytest-datadir-ng"
+        "pytest-datadir-ng",
+        "tox"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -42,6 +43,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development"
     ],
     license="BSD 3-Clause License; partially licensed under the Python Software Foundation License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps =


### PR DESCRIPTION
JProperties has been throwing `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working` for a while now. With Python 3.10 almost out, this issue has become more urgent, so this PR fixes this while maintaining backwards compatibility.

It also adds newer Python versions to the `setup.py` and `tox.ini`. Python 3.10 tests were performed with version 3.10.0b3.

When running the tests for Python 2.7 with version 2.7.16 on Mac OS 11.4 (20F71), the following error occurred:
`ParseError: Parse error in <unknown>:1: unichr() arg not in range(0x10000) (narrow Python build)`
A fix for this is included as well.